### PR TITLE
add additional load and save cases to comply with Tree data

### DIFF
--- a/src/main/java/Interactors/DataAccess.java
+++ b/src/main/java/Interactors/DataAccess.java
@@ -5,6 +5,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 
 public interface DataAccess {
-    ArrayList<String[]> loadGame(String filePath) throws FileNotFoundException;
+    ArrayList<ArrayList<String[]>> loadGame(String filePath) throws FileNotFoundException;
     boolean saveGame(String fileName) throws IOException;
 }


### PR DESCRIPTION
Added treeData and optionData to constructor for TextFileTranslator.

String[][] optionData contains String[] arrays which represent key-value pairs for selectedOptions in Tree. Let me know what this data represents such that I can create the relevant Trees properly in a follow-up gameCreationInteractor PR. This was separated out from String[][] treeData to comply with the ArrayList<ArrayList<String[]>> return type. I tried making an ArrayList<Object[]> to create ArrayLists of arbitrary depth but that implementation causes errors since Java does not match ArrayList<String[]> types to Object[]. (I thought ArrayLists were Objects and thus it may have worked but that appears to be wrong)

String[][] treeData contains [int currentTreeIndex, int currentPlayerIndex], Integer[] tradingStates, Integer[] auctionStates, Integer[] mainStates arrays. This complies with the ArrayList<ArrayList<String[]>> return type.

String[][] playerData contains String[] arrays which represent either a Player instance with its attributes or a Property instance which is owned by a Player. (We may want to change the way Property is saved such that instead of denoting the Player which owns it by an index in the Players[] array, we denote it using the Player's name instance attribute) I will handle the case of differentiating between the two in a follow-up gameCreationInteractor PR.

String[][] boardData contains String[] arrays which represent key-value pairs for the playerPositions. We will have to communicate with useCaseInteractor to determine how this information will be stored. (ex. String Player.name : Integer ) 
I will handle creation of Cells in gameCreationInteractor in a follow-up PR. Players for a Board are parsed as indicated by the playerData array above. 

Notes: 
- We may need a Player constructor which gets passed an ArrayList of Property objects to instantiate a Player who already owns Properties when loading a game. 
- I will add JavaDocs and Unit Tests in a follow-up PR to this branch
